### PR TITLE
create a link component for docs

### DIFF
--- a/community/content/getting-started/composing/create-components/create-components.mdx
+++ b/community/content/getting-started/composing/create-components/create-components.mdx
@@ -2,7 +2,7 @@ import componentImg from './component.png';
 
 # Creating Components
 
-Bit makes it simple to build each [Component](/docs/components/overview) independently, and compose it to others with [Dependencies](/dependencies/overview). Components 
+Bit makes it simple to build each [Component](/components/component-overview) independently, and compose it to others with [Dependencies](/dependencies/dependencies-overview). Components 
 can be created in different types such as Node Modules, React Components, Angular Modules and more. 
 Component types are defined by the configured [development environment (Env)](/docs/getting-started/dev-envs).
 

--- a/community/ui/footer/link/link.docs.mdx
+++ b/community/ui/footer/link/link.docs.mdx
@@ -12,7 +12,3 @@ Modify the text to see it change live:
 ```js live
 <Link text="Bit" icon="https://static.bit.dev/bit-logo.svg" href="https://bit.dev" external />
 ```
-
-### Design
-
-<FigmaEmbed src="url-to-figma" />

--- a/design/ui/navigation/link/link.tsx
+++ b/design/ui/navigation/link/link.tsx
@@ -1,17 +1,8 @@
-import React from "react";
-import classNames from "classnames";
-import {
-  Link as BaseLink,
-  LinkProps,
-} from "@teambit/base-react.navigation.link";
-import styles from "./link.module.scss";
+import React from 'react';
+import classNames from 'classnames';
+import { Link as BaseLink, LinkProps } from '@teambit/base-react.navigation.link';
+import styles from './link.module.scss';
 
 export function Link({ className, activeClassName, ...rest }: LinkProps) {
-  return (
-    <BaseLink
-      className={classNames(styles.link, className)}
-      activeClassName={activeClassName}
-      {...rest}
-    />
-  );
+  return <BaseLink className={classNames(styles.link, className)} activeClassName={activeClassName} {...rest} />;
 }

--- a/docs/ui/community-docs/community-docs.tsx
+++ b/docs/ui/community-docs/community-docs.tsx
@@ -8,17 +8,17 @@ export type CommunityDocsProps = {
   /**
    * base url to use for docs section.
    */
-  baseUrl?: string
+  baseUrl?: string;
 } & Omit<DocsProps, 'routes'>;
 
 export function CommunityDocs({ baseUrl = '/docs', ...rest }: CommunityDocsProps) {
   return (
-    <Docs 
-      {...rest} 
-      routes={docsRoutes} 
-      primaryLinks={primaryRoutes} 
-      baseUrl={baseUrl} 
-      // contribution={<ContributingDocs/>} 
+    <Docs
+      {...rest}
+      routes={docsRoutes}
+      primaryLinks={primaryRoutes}
+      baseUrl={baseUrl}
+      // contribution={<ContributingDocs/>}
     />
   );
 }

--- a/docs/ui/docs/docs.tsx
+++ b/docs/ui/docs/docs.tsx
@@ -68,7 +68,7 @@ export function Docs({
             const next = routeArray[key + 1] ? routeArray[key + 1] : undefined;
             return (
               <Route key={route.title} path={route.absPath}>
-                <DocPage nextPage={next} title={route.title}>
+                <DocPage nextPage={next} title={route.title} baseUrl={baseUrl}>
                   {route.component}
                 </DocPage>
               </Route>

--- a/docs/ui/pages/doc-page/doc-page.tsx
+++ b/docs/ui/pages/doc-page/doc-page.tsx
@@ -1,10 +1,9 @@
 import React, { useRef, useEffect, ReactNode } from 'react';
 import { MDXLayout } from '@teambit/mdx.ui.mdx-layout';
-import type { MDXProviderComponents } from '@teambit/mdx.ui.mdx-layout';
 import { Page } from '@teambit/base-react.pages.page';
 import { NextPage } from '@teambit/community.ui.cards.next-page';
 import type { Route } from '@teambit/docs.entities.docs-routes';
-import { h1 as H1, h2 as H2, h3 as H3 } from '@teambit/documenter.markdown.heading';
+import { mdxComponents } from './mdx-components';
 import styles from './doc-page.module.scss';
 
 export type DocPageProps = {
@@ -22,22 +21,21 @@ export type DocPageProps = {
    * a text to be rendered in the component.
    */
   children: ReactNode;
+
+  /**
+   * base url to use for docs section.
+   */
+  baseUrl?: string;
 };
 
 const scrollToRef = (ref) => {
   return window.scrollTo(0, -ref.current.offsetTop);
 };
 
-const getTextLink = (element: React.ReactNode) =>
-  typeof element === 'string' ? element.trim().toLowerCase().replace(/ /g, '-') : undefined;
+export function DocPage({ title, nextPage, children, baseUrl = '/docs' }: DocPageProps) {
+  const myRef = useRef(null);
+  const executeScroll = () => scrollToRef(myRef);
 
-const mdxComponents: MDXProviderComponents = {
-  h1: ({ children, ...rest }) => <H1 link={getTextLink(children)} children={children} {...rest} />,
-  h2: ({ children, ...rest }) => <H2 link={getTextLink(children)} children={children} {...rest} />,
-  h3: ({ children, ...rest }) => <H3 link={getTextLink(children)} children={children} {...rest} />,
-};
-
-export function DocPage({ title, nextPage, children }: DocPageProps) {
   useEffect(() => {
     executeScroll();
   }, []);
@@ -52,12 +50,10 @@ export function DocPage({ title, nextPage, children }: DocPageProps) {
     }
   }, [location.hash]);
 
-  const myRef = useRef(null);
-  const executeScroll = () => scrollToRef(myRef);
   return (
     <Page title={title}>
       <div ref={myRef} />
-      <MDXLayout components={mdxComponents}>{children}</MDXLayout>
+      <MDXLayout components={mdxComponents(baseUrl)}>{children}</MDXLayout>
 
       {nextPage && (
         <NextPage

--- a/docs/ui/pages/doc-page/mdx-components.tsx
+++ b/docs/ui/pages/doc-page/mdx-components.tsx
@@ -1,0 +1,31 @@
+import React, { ReactNode, HTMLAttributes, AnchorHTMLAttributes } from 'react';
+import type { MDXProviderComponents } from '@teambit/mdx.ui.mdx-layout';
+import { h1 as H1, h2 as H2, h3 as H3 } from '@teambit/documenter.markdown.heading';
+import { Link } from '@teambit/design.ui.navigation.link';
+
+const getTextLink = (element: ReactNode) =>
+  typeof element === 'string' ? element.trim().toLowerCase().replace(/ /g, '-') : undefined;
+
+export const mdxComponents = (baseUrl: string): MDXProviderComponents => {
+  return {
+    h1: ({ children, ...rest }: HTMLAttributes<HTMLHeadingElement>) => (
+      <H1 link={getTextLink(children)} {...rest}>
+        {children}
+      </H1>
+    ),
+    h2: ({ children, ...rest }: HTMLAttributes<HTMLHeadingElement>) => (
+      <H2 link={getTextLink(children)} {...rest}>
+        {children}
+      </H2>
+    ),
+    h3: ({ children, ...rest }: HTMLAttributes<HTMLHeadingElement>) => (
+      <H3 link={getTextLink(children)} {...rest}>
+        {children}
+      </H3>
+    ),
+    a: ({ href, ...rest }: AnchorHTMLAttributes<HTMLAnchorElement>) => {
+      const isExternal = href?.startsWith('http') ? true : undefined;
+      return <Link href={isExternal ? href : `${baseUrl}${href}`} external={isExternal} {...rest} />;
+    },
+  };
+};


### PR DESCRIPTION
closed #39 
- moved mdx object to a separate file.
- added anchor element in mdx components that use Link from design scope.
- use baseUrl prop from community-docs as a prefix for Link element.
- check if the url is external or not.
- fixed some eslint error, and save with prettier.
- fix two internal links in `create-components.mdx` to check the Link component.