### PR TITLE
extract bit dev app configuration to its own file

### DIFF
--- a/community/apps/bit-dev/component.json
+++ b/community/apps/bit-dev/component.json
@@ -1,0 +1,19 @@
+{
+  "componentId": {
+    "scope": "teambit.community",
+    "name": "apps/bit-dev",
+    "version": "1.9.37"
+  },
+  "propagate": false,
+  "extensions": {
+    "teambit.dependencies/dependency-resolver": {
+      "policy": {
+        "dependencies": {
+          "@types/react-router-dom": "5.1.7",
+          "react-router-dom": "5.2.0",
+          "history": "^5.0.1"
+        }
+      }
+    }
+  }
+}

--- a/community/apps/bit-dev/component.json
+++ b/community/apps/bit-dev/component.json
@@ -4,7 +4,7 @@
     "name": "apps/bit-dev",
     "version": "1.9.37"
   },
-  "propagate": false,
+  "propagate": true,
   "extensions": {
     "teambit.dependencies/dependency-resolver": {
       "policy": {

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -165,23 +165,6 @@
    * see https://harmony-docs.bit.dev/aspects/variants for more info.
    **/
   "teambit.workspace/variants": {
-    "{apps/bit-dev}": {
-      "teambit.dependencies/dependency-resolver": {
-        "policy": {
-          "dependencies": {
-            // lock a specific version of react-router for production:
-            // (remove once we get rid of the legacy link components)
-            "@types/react-router-dom": "5.1.7",
-            "react-router-dom": "5.2.0"
-          },
-          "peerDependencies": {
-            "@types/react-router-dom": "-",
-            "react-router-dom": "-",
-            "history": "^5.0.0"
-          }
-        }
-      }
-    },
     "{ui/**}": {
       "teambit.community/envs/community-react": {}
     },


### PR DESCRIPTION
closed #46 

- move the configuration for the app/bit-dev component to its own file (instead of the main workspace.jsonc)