### PR TITLE
fix open close folder when there is no overview configured

### DIFF
--- a/docs/ui/sidebar/node-title/node-title.docs.mdx
+++ b/docs/ui/sidebar/node-title/node-title.docs.mdx
@@ -11,12 +11,5 @@ Besides controlling the opening of a tree node, this component is responsible fo
 ### Component usage
 
 ```js live
-<NodeTitle
-  id="My Folder"
-  icon="dependencies-icn"
-  configPath="config-path"
-  overviewPath={window?.location.pathname}
-  open={false}
-  setOpen={() => {}}
-/>
+<NodeTitle id="My Folder" icon="dependencies-icn" configPath="config-path" open={false} setOpen={() => {}} />
 ```

--- a/docs/ui/sidebar/node-title/node-title.tsx
+++ b/docs/ui/sidebar/node-title/node-title.tsx
@@ -44,6 +44,7 @@ export function NodeTitle({ id, icon, open, configPath, overviewPath, setOpen }:
   const displayName = id.replace(/\/$/, '').split('/').pop();
   const CustomIcon = getCustomIcon(icon);
   const handleOnFolderClick = () => {
+    if (!overviewPath) setOpen(!open);
     // This prevent the folder to be closed when is open and the folder is active.
     if (overviewPath !== window?.location.pathname && !open) setOpen(!open);
   };


### PR DESCRIPTION
closed #118 
Because of this bug, we can't close any folder on the Guides page, and also can't close any folder that does not have an overview configured in the Docs page.