### PR TITLE
Update highlighter (bugfixes)

### DIFF
--- a/docs/ui/highlighter/highlight-component/highlight-component.tsx
+++ b/docs/ui/highlighter/highlight-component/highlight-component.tsx
@@ -1,8 +1,14 @@
 import { Heading, Elements } from '@teambit/community.ui.heading';
-import { MultiHighlighter, ExcludeHighlighter } from '@teambit/react.ui.component-highlighter';
+import {
+  ComponentHighlighter,
+  ExcludeHighlighter,
+  excludeHighlighterAtt,
+} from '@teambit/react.ui.component-highlighter';
 import { ComponentID } from '@teambit/component-id';
 import React, { ReactNode } from 'react';
 import styles from './highlight-component.module.scss';
+
+export { ExcludeHighlighter, excludeHighlighterAtt };
 
 export type HighlightComponentProps = {
   /**
@@ -28,23 +34,20 @@ export type HighlightComponentProps = {
 
 export function HighlightComponent({ children, title }: HighlightComponentProps) {
   return (
-    <MultiHighlighter
+    <ComponentHighlighter
+      mode="allChildren"
       bgColorHover="#C9C3F6"
       bgColor="#ECEAFF"
+      highlightStyle={{ fontSize: 8 }}
       watchMotion
-      // @ts-ignore @Kutner - fix
-      highlighterOptions={{ style: { fontSize: 8 } }}
+      {...excludeHighlighterAtt} // prevent external highlighters from applying inside this one
     >
-      <ExcludeHighlighter>
-        {title ? (
-          <Heading element={Elements.H6} className={styles.heading}>
-            {title}
-          </Heading>
-        ) : (
-          ''
-        )}
-      </ExcludeHighlighter>
+      {title && (
+        <Heading element={Elements.H6} className={styles.heading} {...excludeHighlighterAtt}>
+          {title}
+        </Heading>
+      )}
       {children}
-    </MultiHighlighter>
+    </ComponentHighlighter>
   );
 }

--- a/docs/ui/highlighter/highlight-component/index.ts
+++ b/docs/ui/highlighter/highlight-component/index.ts
@@ -1,2 +1,2 @@
-export { HighlightComponent } from './highlight-component';
+export { HighlightComponent, ExcludeHighlighter } from './highlight-component';
 export type { HighlightComponentProps } from './highlight-component';

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -71,6 +71,7 @@
         "@teambit/base-ui.layout.breakpoints": "1.0.0",
         "@teambit/base-ui.layout.grid-component": "1.0.1",
         "@teambit/base-ui.layout.page-frame": "1.0.1",
+        "@teambit/base-ui.loaders.skeleton": "1.0.1",
         "@teambit/base-ui.routing.native-nav-link": "1.0.0",
         "@teambit/base-ui.routing.routing-provider": "1.0.0",
         "@teambit/base-ui.surfaces.card": "1.0.1",

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -107,7 +107,7 @@
         "@teambit/mdx.ui.mdx-layout": "0.0.475",
         "@teambit/react.eslint-config-bit-react": "0.0.451",
         "@teambit/react.templates.themes.theme": "0.0.3",
-        "@teambit/react.ui.component-highlighter": "0.0.482",
+        "@teambit/react.ui.component-highlighter": "0.0.486",
         "@teambit/ui-foundation.ui.buttons.collapser": "0.0.144",
         "@teambit/ui-foundation.ui.react-router.link": "0.0.441",
         "@teambit/ui-foundation.ui.react-router.nav-link": "0.0.441",


### PR DESCRIPTION
Update component highlighter, with many improvements.
Closed #90 

- better API
- single ComponentHighlighter component with "hover" and "allChildren" mode
- exclusion zone only apply to parent highlighters, so we can nest highlighters like so: `<ExcludeHighlighter><ComponentHighlighter>{...}</ComponentHighlighter></ExcludeHighlighter>`
- show outer most component per highlighted dom element
- new `rule` prop to specify which part of the dom to highlight.

also fix:
- missing dependency on skeleton-loader
- duplicate key in guides page