### PR TITLE
fix: ImportComponents route

### DIFF
--- a/docs/ui/community-docs/getting-started-routes.tsx
+++ b/docs/ui/community-docs/getting-started-routes.tsx
@@ -164,7 +164,7 @@ export const gettingStartedDocsRoutes: DocsRoute[] = [
       {
         path: 'importing-components',
         title: 'Importing components',
-        component: <ShareComponents />,
+        component: <ImportComponents />,
       },
       {
         path: 'exporting-components',


### PR DESCRIPTION
Change route from ShareComponents to ImportComponents for Importing Components section under Collaborate section of getting started.

Resolved: #275