### PR TITLE
fix table over content in doc page and align table to the left

### DIFF
--- a/docs/ui/pages/doc-page/doc-page.module.scss
+++ b/docs/ui/pages/doc-page/doc-page.module.scss
@@ -22,7 +22,6 @@ $textColumn: 1000px;
   .heading,
   ul,
   ol,
-  table,
   pre,
   :global(.admonition) {
     max-width: $textColumn;


### PR DESCRIPTION
closed #319 
The table already have max-width 100% and overflow auto.
https://bit.cloud/teambit/documenter/ui/table/base-table/~code/base-table.module.scss