### PR TITLE
fix arrows also outside the bubble graph

### DIFF
--- a/community/ui/graph/bubble-graph/bubble-graph.tsx
+++ b/community/ui/graph/bubble-graph/bubble-graph.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import classNames from 'classnames';
-import { Xwrapper, useXarrow } from 'react-xarrows';
 import { GridGraph, GridGraphProps } from '@teambit/community.ui.graph.grid-graph';
 import { GridNode } from '@teambit/community.entity.graph.grid-graph';
 import { BubbleNode, BubblePayload } from './bubble-node';
@@ -12,22 +11,8 @@ export type BubbleGraphProps = {
 
 export function BubbleGraph({ nodes, Node = BubbleNode, children, nodeClassName, ...rest }: BubbleGraphProps) {
   return (
-    <Xwrapper>
-      <ReloadArrows />
-      <GridGraph Node={Node} nodes={nodes} nodeClassName={classNames(styles.bubbleContainer, nodeClassName)} {...rest}>
-        {children}
-      </GridGraph>
-    </Xwrapper>
+    <GridGraph Node={Node} nodes={nodes} nodeClassName={classNames(styles.bubbleContainer, nodeClassName)} {...rest}>
+      {children}
+    </GridGraph>
   );
-}
-
-// this will be fixed in react-xarrows v3.0.0
-function ReloadArrows() {
-  const updateXarrow = useXarrow();
-
-  useEffect(() => {
-    updateXarrow();
-  }, []);
-
-  return null;
 }

--- a/community/ui/graph/edge/auto-reloader.tsx
+++ b/community/ui/graph/edge/auto-reloader.tsx
@@ -1,0 +1,28 @@
+import React, { PropsWithChildren, useEffect } from 'react';
+import { Xwrapper, useXarrow } from 'react-xarrows';
+
+export type ArrowAutoReloaderProps = PropsWithChildren<{}>;
+
+/**
+ * automatically reloads arrows on mount
+ * this solves some glitches on first time rendering
+ */
+export function ArrowAutoReloader({ children }: ArrowAutoReloaderProps) {
+  return (
+    <Xwrapper>
+      {children}
+      <ReloadArrows />
+    </Xwrapper>
+  );
+}
+
+// this will be fixed in react-xarrows v3.0.0
+function ReloadArrows() {
+  const updateXarrow = useXarrow();
+
+  useEffect(() => {
+    updateXarrow();
+  }, []);
+
+  return null;
+}

--- a/community/ui/graph/edge/index.ts
+++ b/community/ui/graph/edge/index.ts
@@ -1,2 +1,5 @@
 export { Edge } from './edge';
 export type { EdgeProps } from './edge';
+
+export { ArrowAutoReloader } from './auto-reloader';
+export type { ArrowAutoReloaderProps } from './auto-reloader';

--- a/community/ui/graph/grid-graph/grid-graph.tsx
+++ b/community/ui/graph/grid-graph/grid-graph.tsx
@@ -1,15 +1,9 @@
 import React, { ComponentType, useMemo } from 'react';
 import { ComponentID } from '@teambit/component-id';
 import classNames from 'classnames';
-import {
-  GridNode,
-  DependencyEdge,
-} from '@teambit/community.entity.graph.grid-graph';
-import { Edge as DefaultEdge } from '@teambit/community.ui.graph.edge';
-import {
-  graphNodeLayout,
-  Sizes,
-} from '@teambit/base-react.ui.layout.graph-node';
+import { GridNode, DependencyEdge } from '@teambit/community.entity.graph.grid-graph';
+import { Edge as DefaultEdge, ArrowAutoReloader } from '@teambit/community.ui.graph.edge';
+import { graphNodeLayout, Sizes } from '@teambit/base-react.ui.layout.graph-node';
 import { DefaultNode } from './default-node';
 import { getValidId } from './utils';
 import type { PositionsType } from './utils';
@@ -68,19 +62,21 @@ export function GridGraph({
 }: GridGraphProps) {
   return (
     <div className={classNames(styles.gridGraph, className)} {...rest}>
-      {nodes.map((node) => {
-        const id = getValidId(node.id.toString({ ignoreVersion: true }));
-        return (
-          <GraphNode
-            key={id}
-            Edge={Edge}
-            Node={Node}
-            nodeContent={node}
-            className={nodeClassName}
-            nodeLayout={nodeLayout}
-          />
-        );
-      })}
+      <ArrowAutoReloader>
+        {nodes.map((node) => {
+          const id = getValidId(node.id.toString({ ignoreVersion: true }));
+          return (
+            <GraphNode
+              key={id}
+              Edge={Edge}
+              Node={Node}
+              nodeContent={node}
+              className={nodeClassName}
+              nodeLayout={nodeLayout}
+            />
+          );
+        })}
+      </ArrowAutoReloader>
       {children}
     </div>
   );
@@ -97,15 +93,7 @@ function GraphNode<T>({
   Edge = DefaultEdge,
   nodeLayout = graphNodeLayout,
 }: GridGraphNodeProps<T>) {
-  const {
-    id,
-    attrId,
-    dependencies,
-    position = '',
-    sizes,
-    col,
-    row,
-  } = nodeContent || {};
+  const { id, attrId, dependencies, position = '', sizes, col, row } = nodeContent || {};
   const cellLayout = useMemo(() => {
     return nodeLayout(sizes, row, col);
   }, [sizes]);
@@ -119,13 +107,7 @@ function GraphNode<T>({
       <Node id={attrId} node={nodeContent} />
 
       {dependencies.map((dependency) => {
-        return (
-          <Edge
-            key={`${attrId}->${dependency.attrId}`}
-            node={nodeContent}
-            dependency={dependency}
-          />
-        );
+        return <Edge key={`${attrId}->${dependency.attrId}`} node={nodeContent} dependency={dependency} />;
       })}
     </div>
   );

--- a/community/ui/sections/component-distribution/component-distribution.tsx
+++ b/community/ui/sections/component-distribution/component-distribution.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { Image } from '@teambit/base-react.content.image';
 import { Link } from '@teambit/design.ui.navigation.link';
 import { Heading, Elements } from '@teambit/community.ui.heading';
-import { Edge } from '@teambit/community.ui.graph.edge';
+import { Edge, ArrowAutoReloader } from '@teambit/community.ui.graph.edge';
 import { ComponentCardGraph } from '@teambit/community.ui.graph.component-card-graph';
 import { ComponentCardNode } from '@teambit/community.entity.compnent-distribution-graph';
 import { top, bottom } from './component-distribution.mock';
@@ -24,27 +24,29 @@ export type ComponentDistributionSectionProps = {
 
 export function ComponentDistributionSection({ title, components = [], className }: ComponentDistributionSectionProps) {
   return (
-    <div className={classNames(styles.buildSection, className)}>
-      <div className={styles.heading}>
-        <Heading element={Elements.H3} className={styles.title}>
-          {title}
-        </Heading>
+    <ArrowAutoReloader>
+      <div className={classNames(styles.buildSection, className)}>
+        <div className={styles.heading}>
+          <Heading element={Elements.H3} className={styles.title}>
+            {title}
+          </Heading>
+        </div>
+        {/* created a connecting element for edge curve effect */}
+        <div id={top.attrId} className={styles.connectingEdgeAnchor}>
+          <Edge node={top} dependency={top.dependencies[0]} />
+          <Edge node={top} dependency={top.dependencies[1]} />
+        </div>
+        <ComponentCardGraph nodes={components} className={styles.distributionGraph}>
+          <Link href="https://bit.dev/learn-bit-react/shoe-store/apps/shoe-store" external className={styles.appLink}>
+            <Image src={img} className={styles.appImg} id="learn-bit-react-image-image" />
+          </Link>
+        </ComponentCardGraph>
+        {/* created a connecting element for edge curve effect */}
+        <div id={bottom.attrId} className={styles.connectingEdgeAnchor}>
+          <Edge node={bottom} dependency={bottom.dependencies[0]} />
+          <Edge node={bottom} dependency={bottom.dependencies[1]} />
+        </div>
       </div>
-      {/* created a connecting element for edge curve effect */}
-      <div id={top.attrId} className={styles.connectingEdgeAnchor}>
-        <Edge node={top} dependency={top.dependencies[0]} />
-        <Edge node={top} dependency={top.dependencies[1]} />
-      </div>
-      <ComponentCardGraph nodes={components} className={styles.distributionGraph}>
-        <Link href="https://bit.dev/learn-bit-react/shoe-store/apps/shoe-store" external className={styles.appLink}>
-          <Image src={img} className={styles.appImg} id="learn-bit-react-image-image" />
-        </Link>
-      </ComponentCardGraph>
-      {/* created a connecting element for edge curve effect */}
-      <div id={bottom.attrId} className={styles.connectingEdgeAnchor}>
-        <Edge node={bottom} dependency={bottom.dependencies[0]} />
-        <Edge node={bottom} dependency={bottom.dependencies[1]} />
-      </div>
-    </div>
+    </ArrowAutoReloader>
   );
 }


### PR DESCRIPTION
closed #316 

- moved the logic to the edge component, as `<ArrowAutoReloader>`
- applied the auto reloader at the GridGraph instead of the bubble graph, which already has a dependency on the arrows.
- also applied the reloader in the "component-distribution" section