### PR TITLE
add warning for setx path for windows users #343

### DIFF
--- a/docs/content/guides/using-bvm/using-bvm.mdx
+++ b/docs/content/guides/using-bvm/using-bvm.mdx
@@ -48,6 +48,12 @@ If you get this error, run:
 setx path "%path%;%AppData%\npm" and re-open your terminal
 ```
 
+:::note
+Important! Make sure to copy and store your path variable before running the above command, so that you can restore your path if needed (e.g. if it exceeds the maximum path length). 
+If it does exceed the maximum, you will likely be able to reduce its current length by using common path aliases such as `%AppData% used above, which replaces the full path 
+to your user's AppData folder.
+:::
+
 #### MacOS/Linux
 
 ```bash with Zsh


### PR DESCRIPTION
Add warning for Windows user so that they don't by mistake overwrite their path variable if the command we supply pushes them over the max char limit for Path
closed #343 