### PR TITLE
reload arrows on page load

### DIFF
--- a/community/ui/graph/grid-graph/grid-graph.tsx
+++ b/community/ui/graph/grid-graph/grid-graph.tsx
@@ -62,7 +62,7 @@ export function GridGraph({
 }: GridGraphProps) {
   return (
     <div className={classNames(styles.gridGraph, className)} {...rest}>
-      <ArrowAutoReloader interval>
+      <ArrowAutoReloader reloadOnTimeout={300} reloadOnMount>
         {nodes.map((node) => {
           const id = getValidId(node.id.toString({ ignoreVersion: true }));
           return (

--- a/community/ui/sections/component-distribution/component-distribution.tsx
+++ b/community/ui/sections/component-distribution/component-distribution.tsx
@@ -24,7 +24,7 @@ export type ComponentDistributionSectionProps = {
 
 export function ComponentDistributionSection({ title, components = [], className }: ComponentDistributionSectionProps) {
   return (
-    <ArrowAutoReloader interval>
+    <ArrowAutoReloader reloadOnTimeout={300} reloadOnMount>
       <div className={classNames(styles.buildSection, className)}>
         <div className={styles.heading}>
           <Heading element={Elements.H3} className={styles.title}>


### PR DESCRIPTION
closed #316 
this ensures the arrows are rendered correctly by reloading after 300ms, and on page load events.
This is the time where almost all dom changes occur, which made most of our problems.