### PR TITLE
Install new version of cloud provider with new domain changes

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -79,7 +79,7 @@
         "@teambit/base-ui.text.paragraph": "^1.0.3",
         "@teambit/blog.starter.starter-blog": "0.0.7",
         "@teambit/cloud-providers.deployers.netlify": "0.0.8",
-        "@teambit/cloud.cloud-provider": "0.0.6",
+        "@teambit/cloud.cloud-provider": "0.0.20",
         "@teambit/community.entity.graph.bubble-graph": "^1.23.11",
         "@teambit/community.ui.sticky-banner": "0.0.5",
         "@teambit/community.ui.text-tooltip": "0.0.6",


### PR DESCRIPTION
closed #368 

This is the actual installed version 0.0.6:
![image](https://user-images.githubusercontent.com/35892475/161432091-bc5f3ab5-1384-441e-8ace-4aa29f07ff4f.png)

And this is the latest with the correct domain:
![image](https://user-images.githubusercontent.com/35892475/161432135-550487ec-9c30-495c-a485-e3f1952b8f92.png)
