### PR TITLE
:zap: fix header z-index issue on element hover

### DIFF
--- a/design/blocks/header/header.module.scss
+++ b/design/blocks/header/header.module.scss
@@ -11,6 +11,7 @@
   @include breakpoints.media-md {
     --header-spacing: 0.5em;
   }
+  z-index: 100000;
 }
 
 .headerContent {


### PR DESCRIPTION
While scrolling the page and hovering over the elements to see components being used, it overlaps `BasicHeader` content and gives a bad experience to the user.

Ideally, the header and its child component should have high z-index than any other component if they're sticky in nature.

![Screenshot 2022-04-30 at 2 55 18 PM](https://user-images.githubusercontent.com/27219302/166121235-4532f16c-5f87-4830-ae45-96a069e97470.png)

