### PR TITLE
basic prerendering

### DIFF
--- a/community/apps/bit-dev/bit-dev.react-app.ts
+++ b/community/apps/bit-dev/bit-dev.react-app.ts
@@ -14,9 +14,20 @@ export const BitDevApp: ReactAppOptions = {
   entry: [require.resolve('./bit-dev.app-root')],
   deploy: Netlify.deploy(netlify),
   // webpackTransformers: [faviconWebpackTransformer],
-  // prerender: {
-  //   routes: ['/', '/aspects', '/docs'], //TODO: breaks on production
-  // },
+  prerender: {
+    routes: [
+      '/',
+      '/aspects',
+      '/docs',
+      '/docs/thinking-in-components',
+      '/docs/quick-start',
+      '/docs/quick-start/wiki',
+      '/docs/quick-start/design',
+      '/docs/quick-start/analytics',
+      '/docs/quick-start/data-fetching',
+      '/docs/quick-start/basic-react',
+    ],
+  },
 };
 
 export default BitDevApp;

--- a/community/ui/router/router-provider/legacy-routing.ts
+++ b/community/ui/router/router-provider/legacy-routing.ts
@@ -4,8 +4,8 @@ import type { Routing } from '@teambit/base-ui.routing.routing-provider';
 import { reactRouterAdapter } from '@teambit/ui-foundation.ui.navigation.react-router-adapter';
 
 export const legacyRouting: Routing = {
-  Link: reactRouterAdapter.Link,
-  NavLink: reactRouterAdapter.Link,
+  Link: reactRouterAdapter.Link!,
+  NavLink: reactRouterAdapter.Link!,
   // @ts-ignore
   useLocation: reactRouterAdapter.useLocation,
 };

--- a/docs/ui/pages/doc-page/mdx-components.tsx
+++ b/docs/ui/pages/doc-page/mdx-components.tsx
@@ -10,6 +10,7 @@ const getTextLink = (element: ReactNode) =>
 
 export const mdxComponents = (baseUrl: string, selectorClassName?: string): MDXProviderComponents => {
   return {
+    // @ts-ignore - https://github.com/teambit/bit/issues/5746
     wrapper: 'div',
     h1: ({ children, className, ...rest }: HTMLAttributes<HTMLHeadingElement>) => (
       <H1 className={classNames(selectorClassName, className, styles.heading)} link={getTextLink(children)} {...rest}>

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -135,7 +135,7 @@
         "@teambit/documenter.ui.sub-title": "^4.1.1",
         "@teambit/evangelist.surfaces.tooltip": "^1.0.1",
         "@teambit/explorer.plugins.preview-plugin": "0.0.7",
-        "@teambit/explorer.ui.command-bar": "1.0.2",
+        "@teambit/explorer.ui.command-bar": "1.1.0",
         "@teambit/explorer.ui.component-card": "0.0.9",
         "@teambit/explorer.ui.gallery.component-card": "^0.0.470",
         "@teambit/explorer.ui.gallery.component-grid": "^0.0.435",


### PR DESCRIPTION
closed #357 

enable prerendering for these routes:
- '/',
- '/aspects',
- '/docs',
- '/docs/thinking-in-components',
- '/docs/quick-start',
- '/docs/quick-start/wiki',
- '/docs/quick-start/design',
- '/docs/quick-start/analytics',
- '/docs/quick-start/data-fetching',
- '/docs/quick-start/basic-react',

also fixed some type errors